### PR TITLE
Removing `.DS_Store` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store


### PR DESCRIPTION
`.DS_Store` is a Mac internal file for tracking things like icon positions in the Finder. It's not important to the codebase.

Removing the `.DS_Store` files and creating a `.gitignore` file with that listed so that it won't get added again in the future.